### PR TITLE
Fix issues in analyzer

### DIFF
--- a/spec/analyzer/analyzer_spring_spec.cr
+++ b/spec/analyzer/analyzer_spring_spec.cr
@@ -47,6 +47,12 @@ describe "mapping_to_path" do
   it "mapping_to_path - requestmapping style3" do
     instance.mapping_to_path("@RequestMapping(value = \"/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ\")").should eq(["/0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"])
   end
+  it "mapping_to_path - requestmapping style4" do
+    instance.mapping_to_path("@GetMapping()").should eq([""])
+  end
+  it "mapping_to_path - requestmapping style5" do
+    instance.mapping_to_path("@RequestMapping(method = RequestMethod.GET)").should eq([""])
+  end
 end
 
 describe "utils func" do

--- a/src/analyzer/analyzers/analyzer_django.cr
+++ b/src/analyzer/analyzers/analyzer_django.cr
@@ -59,7 +59,7 @@ class AnalyzerDjango < Analyzer
         path = "/#{path}"
       end
 
-      endpoints << Endpoint.new(path, "GET")
+      endpoints << Endpoint.new("#{@url}#{path}", "GET")
     end
 
     endpoints
@@ -83,6 +83,10 @@ class AnalyzerDjango < Analyzer
       path = match[1]
       view = match[2]
 
+      path = path.gsub(/ /, "")
+      path = path.gsub(/^\^/, "")
+      path = path.gsub(/\$$/, "")
+
       filepath = nil
       view.scan(REGEX_INCLUDE_URLS) do |include_pattern_match|
         next if include_pattern_match.size != 2
@@ -96,14 +100,11 @@ class AnalyzerDjango < Analyzer
           end
         end
       end
-      path = path.gsub(/ /, "")
-      path = path.gsub(/^\^/, "")
-      path = path.gsub(/\$$/, "")
 
       unless path.starts_with?("/")
         path = "/#{path}"
       end
-      paths << path
+      paths << "#{prefix}#{path}"
     end
 
     paths

--- a/src/analyzer/analyzers/analyzer_django.cr
+++ b/src/analyzer/analyzers/analyzer_django.cr
@@ -34,7 +34,7 @@ class AnalyzerDjango < Analyzer
       spawn do
         next if File.directory?(file)
         if file.ends_with? ".py"
-          content = File.read(file)
+          content = File.read(file, encoding: "utf-8", invalid: :skip)
           content.scan(REGEX_ROOT_URLCONF) do |match|
             next if match.size != 2
             filepath = "#{base_path}/#{match[1].gsub(".", "/")}.py"
@@ -67,7 +67,7 @@ class AnalyzerDjango < Analyzer
 
   def get_paths(django_urls : DjangoUrls)
     paths = [] of String
-    content = File.read(django_urls.filepath)
+    content = File.read(django_urls.filepath, encoding: "utf-8", invalid: :skip)
     content.scan(REGEX_URL_PATTERNS) do |match|
       next if match.size != 2
       paths = mapping_to_path(match[1], django_urls.prefix)
@@ -89,7 +89,7 @@ class AnalyzerDjango < Analyzer
         filepath = "#{base_path}/#{include_pattern_match[1].gsub(".", "/")}.py"
 
         if File.exists?(filepath)
-          new_django_urls = DjangoUrls.new("#{prefix}#{url}", filepath)
+          new_django_urls = DjangoUrls.new("#{prefix}#{path}", filepath)
           new_paths = get_paths(new_django_urls)
           new_paths.each do |new_path|
             paths << new_path
@@ -103,7 +103,6 @@ class AnalyzerDjango < Analyzer
       unless path.starts_with?("/")
         path = "/#{path}"
       end
-
       paths << path
     end
 

--- a/src/analyzer/analyzers/analyzer_example.cr
+++ b/src/analyzer/analyzers/analyzer_example.cr
@@ -6,7 +6,7 @@ class AnalyzerExample < Analyzer
     Dir.glob("#{base_path}/**/*") do |path|
       next if File.directory?(path)
       if File.exists?(path)
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           file.each_line do |_|
           end
         end

--- a/src/analyzer/analyzers/analyzer_express.cr
+++ b/src/analyzer/analyzers/analyzer_express.cr
@@ -16,7 +16,7 @@ def analyzer_express(options : Hash(Symbol, String))
   Dir.glob("#{base_path}/**/*") do |path|
     next if File.directory?(path)
     if File.exists?(path)
-      File.open(path, "r") do |file|
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
         file.each_line do |line|
           if line.includes? ".get('/"
             api_path = express_get_endpoint(line)

--- a/src/analyzer/analyzers/analyzer_flask.cr
+++ b/src/analyzer/analyzers/analyzer_flask.cr
@@ -6,7 +6,7 @@ class AnalyzerFlask < Analyzer
     Dir.glob("#{base_path}/**/*") do |path|
       next if File.directory?(path)
       if File.exists?(path) && File.extname(path) == ".py"
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           file.each_line do |line|
             line.strip.scan(/@app\.route\((.*)\)/) do |match|
               if match.size > 0

--- a/src/analyzer/analyzers/analyzer_go_echo.cr
+++ b/src/analyzer/analyzers/analyzer_go_echo.cr
@@ -7,7 +7,7 @@ class AnalyzerGoEcho < Analyzer
     Dir.glob("#{base_path}/**/*") do |path|
       next if File.directory?(path)
       if File.exists?(path) && File.extname(path) == ".go"
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           file.each_line do |line|
             if line.includes?(".GET(") || line.includes?(".POST(") || line.includes?(".PUT(") || line.includes?(".DELETE(")
               get_route_path(line).tap do |route_path|

--- a/src/analyzer/analyzers/analyzer_kemal.cr
+++ b/src/analyzer/analyzers/analyzer_kemal.cr
@@ -6,7 +6,7 @@ class AnalyzerKemal < Analyzer
     Dir.glob("#{@base_path}/**/*") do |path|
       next if File.directory?(path)
       if File.exists?(path) && File.extname(path) == ".cr" && !path.includes?("spec") && !path.includes?("lib")
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           last_endpoint = Endpoint.new("", "")
           file.each_line do |line|
             endpoint = line_to_endpoint(line)

--- a/src/analyzer/analyzers/analyzer_php_pure.cr
+++ b/src/analyzer/analyzers/analyzer_php_pure.cr
@@ -14,7 +14,7 @@ class AnalyzerPhpPure < Analyzer
       relative_path = remove_start_slash(relative_path)
 
       if File.exists?(path) && File.extname(path) == ".php"
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           params_query = [] of Param
           params_body = [] of Param
           methods = [] of String

--- a/src/analyzer/analyzers/analyzer_rails.cr
+++ b/src/analyzer/analyzers/analyzer_rails.cr
@@ -11,7 +11,7 @@ class AnalyzerRails < Analyzer
 
     # Config Analysis
     if File.exists?("#{@base_path}/config/routes.rb")
-      File.open("#{@base_path}/config/routes.rb", "r") do |file|
+      File.open("#{@base_path}/config/routes.rb", "r", encoding: "utf-8", invalid: :skip) do |file|
         file.each_line do |line|
           stripped_line = line.strip
           if stripped_line.size > 0 && stripped_line[0] != '#'
@@ -53,7 +53,7 @@ class AnalyzerRails < Analyzer
     @result = [] of Endpoint
 
     if File.exists?(path)
-      File.open(path, "r") do |controller_file|
+      File.open(path, "r", encoding: "utf-8", invalid: :skip) do |controller_file|
         param_type = "form"
         params_query = [] of Param
         params_body = [] of Param

--- a/src/analyzer/analyzers/analyzer_sinatra.cr
+++ b/src/analyzer/analyzers/analyzer_sinatra.cr
@@ -6,7 +6,7 @@ class AnalyzerSinatra < Analyzer
     Dir.glob("#{@base_path}/**/*") do |path|
       next if File.directory?(path)
       if File.exists?(path)
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           last_endpoint = Endpoint.new("", "")
           file.each_line do |line|
             endpoint = line_to_endpoint(line)

--- a/src/analyzer/analyzers/analyzer_spring.cr
+++ b/src/analyzer/analyzers/analyzer_spring.cr
@@ -9,7 +9,7 @@ class AnalyzerSpring < Analyzer
       next if File.directory?(path)
 
       url = @url
-      if File.exists?(path)
+      if File.exists?(path) && path.ends_with?(".java")
         File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           has_class_been_imported = false
           file.each_line do |line|
@@ -98,16 +98,23 @@ class AnalyzerSpring < Analyzer
             paths << line
           else
             line = comma_in_bracket(line)
+            value_flag = false
             line.split(",").each do |comma_line|
               if comma_line.to_s.includes? "value="
                 tmp = comma_line.split("=")
                 tmp[1].gsub(/"|\)/, "").strip.split("_BRACKET_COMMA_").each do |path|
                   paths << "#{path.strip.gsub("\\", "").gsub(";", "")}"
+                  value_flag = true
                 end
               end
             end
+            if value_flag == false
+              paths << ""
+            end
           end
         end
+      else
+        paths << ""
       end
     end
 

--- a/src/analyzer/analyzers/analyzer_spring.cr
+++ b/src/analyzer/analyzers/analyzer_spring.cr
@@ -10,7 +10,7 @@ class AnalyzerSpring < Analyzer
 
       url = @url
       if File.exists?(path)
-        File.open(path, "r") do |file|
+        File.open(path, "r", encoding: "utf-8", invalid: :skip) do |file|
           has_class_been_imported = false
           file.each_line do |line|
             if has_class_been_imported == false && REGEX_CLASS_DEFINITION.match(line)

--- a/src/detector/detector.cr
+++ b/src/detector/detector.cr
@@ -20,7 +20,7 @@ def detect_techs(base_path : String, options : Hash(Symbol, String))
   Dir.glob("#{base_path}/**/*") do |file|
     spawn do
       next if File.directory?(file)
-      content = File.read(file)
+      content = File.read(file, encoding: "utf-8", invalid: :skip)
 
       detector_list.each do |detector|
         if detector.detect(file, content)


### PR DESCRIPTION
### Issues
1. Invalid UTF-8 characters can cause regex to crash (ref: [Crystal-lang Issue #13237](https://github.com/crystal-lang/crystal/issues/13237)).
2. Django analyzer's failure to properly append URL prefixes.
3. Spring analyzer can scan non-Java files, which can lead to a crash.
4. Spring analyzer can't identify cases where the path is empty, using the example at https://github.com/ksg97031/spring-demo/blob/main/src/main/java/com/example/demo/controller/TestController2.java#L8-L16.

### Fixes
1. The file is now read with UTF-8 encoding and skip invalid characters.
2. The URL prefix is now appended accurately by the Django analyzer.
3. The Spring analyzer has been modified to focus exclusively on scanning '.java' files.
4. The Spring analyzer has been updated to successfully detect controllers of empty paths.